### PR TITLE
Add schema rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const onEnter     = require('./onEnter');
 const onTab       = require('./onTab');
 const onBackspace = require('./onBackspace');
+const makeSchema  = require('./makeSchema');
 
 const KEY_ENTER     = 'enter';
 const KEY_TAB       = 'tab';
@@ -40,7 +41,7 @@ function EditCode(opts) {
         case KEY_TAB:
             return onTab(e, data, state);
         case KEY_BACKSPACE:
-            return  onBackspace(e, data, state);
+            return onBackspace(e, data, state);
         }
     }
 
@@ -71,9 +72,15 @@ function EditCode(opts) {
             .apply();
     }
 
+    const schema = makeSchema({
+        onlyIn: opts.onlyIn
+    });
+
     return {
         onKeyDown,
-        onPaste
+        onPaste,
+
+        schema
     };
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ function defaultOnlyIn(node) {
 
 /**
  * A Slate plugin to handle keyboard events in code blocks.
+ * @param {Function} [opts.onlyIn] Filter for code blocks
  * @return {Object}
  */
 

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -69,7 +69,15 @@ function noMarks(onlyIn) {
             }
         },
 
-        normalize: normalizeChildren
+        normalize (transform, node, value) {
+            const selection = transform.state.selection;
+            const range = selection.moveToRangeOf(node);
+
+            return value.removeMarks.reduce(
+                (tr, mark) => tr.removeMarkAtRange(range, mark),
+                transform
+            );
+        }
     };
 }
 

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,4 +1,5 @@
 const { Set } = require('immutable');
+const Slate = require('slate');
 
 const EMPTY_TEXT = {
     kind: 'text'
@@ -31,8 +32,9 @@ function onlyText(onlyIn) {
             const texts = node.nodes.filter(n => n.kind === 'text');
 
             if (node.nodes.isEmpty() || texts.isEmpty()) {
+                // No text nodes, put one
                 return {
-                    nodes: [EMPTY_TEXT]
+                    nodes: [new Slate.Text()]
                 };
             } else if (node.nodes.size === 1) {
                 // There is a single text node -> valid
@@ -40,12 +42,17 @@ function onlyText(onlyIn) {
             } else {
                 // Keep only the text nodes
                 return {
-                    nodes: [texts]
+                    nodes: texts
                 };
             }
         },
 
-        normalize: normalizeChildren
+        normalize: function normalizeChildren(transform, node, value) {
+            return transform.setNodeByKey(node.key, {
+                nodes: value.nodes
+            });
+        }
+
     };
 }
 
@@ -99,16 +106,6 @@ function getMarks(node) {
     );
 
     return marks;
-}
-
-/**
- * Rule normalization that replaces the node's children
- * @param {List<Nodes>} nodes
- */
-function normalizeChildren(transform, node, nodes) {
-    return transform.setNodeByKey(node.key, {
-        nodes
-    });
 }
 
 module.exports = makeSchema;

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,0 +1,106 @@
+const { Set } = require('immutable');
+
+const EMPTY_TEXT = {
+    kind: 'text'
+};
+
+/**
+ * Create a schema for code blocks.
+ * @param {Object} opts
+ * @param {Function} opts.onlyIn Filter for code blocks
+ */
+function makeSchema(opts) {
+    return {
+        rules: [
+            onlyText(opts.onlyIn),
+            noMarks(opts.onlyIn)
+        ]
+    };
+}
+
+/**
+ * @param {Function} onlyIn Filter for code blocks
+ * @return {Object} A rule that ensure code blocks only contain text
+ * nodes.
+ */
+function onlyText(onlyIn) {
+    return {
+        match: onlyIn,
+
+        validate (node) {
+            const texts = node.nodes.filter(n => n.kind === 'text');
+
+            if (node.nodes.isEmpty() || texts.isEmpty()) {
+                return {
+                    nodes: [EMPTY_TEXT]
+                };
+            } else if (node.nodes.size === 1) {
+                // There is a single text node -> valid
+                return null;
+            } else {
+                // Keep only the text nodes
+                return {
+                    nodes: [texts]
+                };
+            }
+        },
+
+        normalize: normalizeChildren
+    };
+}
+
+/**
+ * @param {Function} onlyIn Filter for code blocks
+ * @return {Object} A rule that ensure code blocks contains no marks
+ */
+function noMarks(onlyIn) {
+    return {
+        match: onlyIn,
+
+        validate (node) {
+            const marks = getMarks(node);
+
+            if (marks.isEmpty()) {
+                return null;
+            } else {
+                return {
+                    removeMarks: marks
+                };
+            }
+        },
+
+        normalize: normalizeChildren
+    };
+}
+
+/**
+ * @param {Node} node
+ * @return {Set<Marks>} All the marks in the node
+ */
+function getMarks(node) {
+    const texts = node.getTexts();
+
+    const marks = texts.reduce(
+        function (marks, text) {
+            return text.characters.reduce(
+                (marks, chars) => marks.union(chars.marks),
+                marks
+            );
+        },
+        new Set()
+    );
+
+    return marks;
+}
+
+/**
+ * Rule normalization that replaces the node's children
+ * @param {List<Nodes>} nodes
+ */
+function normalizeChildren(transform, node, nodes) {
+    return transform.setNodeByKey(node.key, {
+        nodes
+    });
+}
+
+module.exports = makeSchema;

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -5,6 +5,7 @@ const Slate = require('slate');
  * Create a schema for code blocks.
  * @param {Object} opts
  * @param {Function} opts.onlyIn Filter for code blocks
+ * @return {Object} A schema definition with normalization rules
  */
 function makeSchema(opts) {
     return {

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,10 +1,6 @@
 const { Set } = require('immutable');
 const Slate = require('slate');
 
-const EMPTY_TEXT = {
-    kind: 'text'
-};
-
 /**
  * Create a schema for code blocks.
  * @param {Object} opts

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -44,12 +44,15 @@ function onlyText(onlyIn) {
             }
         },
 
-        normalize: function normalizeChildren(transform, node, value) {
+        /**
+         * Replaces the node's children
+         * @param {List<Nodes>} value.nodes
+         */
+        normalize (transform, node, value) {
             return transform.setNodeByKey(node.key, {
                 nodes: value.nodes
             });
         }
-
     };
 }
 
@@ -73,6 +76,10 @@ function noMarks(onlyIn) {
             }
         },
 
+        /**
+         * Removes the given marks
+         * @param {Set<Marks>} value.removeMarks
+         */
         normalize (transform, node, value) {
             const selection = transform.state.selection;
             const range = selection.moveToRangeOf(node);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.11.2"
+    "slate": "^0.13.6"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/tests/schema-no-marks/expected.yaml
+++ b/tests/schema-no-marks/expected.yaml
@@ -1,0 +1,7 @@
+
+nodes:
+  - kind: block
+    type: code_block
+    nodes:
+      - kind: text
+        text: "Some formatted text"

--- a/tests/schema-no-marks/input.yaml
+++ b/tests/schema-no-marks/input.yaml
@@ -1,0 +1,12 @@
+
+nodes:
+  - kind: block
+    type: code_block
+    nodes:
+      - kind: text
+        ranges:
+          - text: 'Some '
+          - text: 'formatted'
+            marks:
+              - type: 'italic'
+          - text: ' text'

--- a/tests/schema-no-marks/transform.js
+++ b/tests/schema-no-marks/transform.js
@@ -1,0 +1,7 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    const normalized = state.normalize(schema);
+    return normalized;
+};

--- a/tests/schema-only-text/expected.yaml
+++ b/tests/schema-only-text/expected.yaml
@@ -1,0 +1,7 @@
+
+nodes:
+  - kind: block
+    type: code_block
+    nodes:
+      - kind: text
+        text: ""

--- a/tests/schema-only-text/input.yaml
+++ b/tests/schema-only-text/input.yaml
@@ -1,0 +1,11 @@
+
+nodes:
+  - kind: block
+    type: code_block
+    nodes:
+      # Contains another block instead of just text nodes
+      - kind: block
+        type: default
+        nodes:
+          - kind: text
+            text: "Some\n code"

--- a/tests/schema-only-text/transform.js
+++ b/tests/schema-only-text/transform.js
@@ -1,0 +1,7 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    const normalized = state.normalize(schema);
+    return normalized;
+};


### PR DESCRIPTION
This adds a two simple rules that help validate and normalize a State containing code blocks.

1. Code blocks can only contain Text nodes as children.
2. Code blocks never contains any Marks.