### PR TITLE
updating example instructions to match functionality

### DIFF
--- a/example/state.json
+++ b/example/state.json
@@ -22,7 +22,7 @@
                     "kind": "text",
                     "ranges": [
                         {
-                            "text": "This page is a basic example of Slate + slate-edit-code plugin. Press Tab to indent code. Shift+Tab to unindent. Press Enter to carry indentation onto the newline. Press Shift+Enter to exit the code block."
+                            "text": "This page is a basic example of Slate + slate-edit-code plugin. Press Tab to indent code. Shift+Tab to unindent. Press Enter to carry indentation onto the newline. Press Cmd (or Ctrl on Windows) + Enter to exit the code block."
                         }
                     ]
                 }

--- a/example/state.json
+++ b/example/state.json
@@ -22,7 +22,7 @@
                     "kind": "text",
                     "ranges": [
                         {
-                            "text": "This page is a basic example of Slate + slate-edit-code plugin. Press Tab to indent code. Shift+Tab to unindent. Press Enter to carry indentation onto the newline. Press Cmd (or Ctrl on Windows) + Enter to exit the code block."
+                            "text": "This page is a basic example of Slate + slate-edit-code plugin. Press Tab to indent code. Shift+Tab to unindent. Press Enter to carry indentation onto the newline. Press Mod (Cmd on Mac, Ctrl on Windows) + Enter to exit the code block."
                         }
                     ]
                 }


### PR DESCRIPTION
Hey guys! A simple instruction patch to make sure the example reflects the behavior (for exiting code block). I thought it was broken until I re-read the README and noticed.

Hope this helps!