### PR TITLE
Add option "onExit"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.10.3
+
+- Added `onExit(transform: Transform): ?Transform` option
+
 ### 0.10.2
 
 - Upgrade to slate^0.19.7

--- a/lib/onModEnter.js
+++ b/lib/onModEnter.js
@@ -11,10 +11,11 @@ function onModEnter(event, data, state, opts) {
 
     // Exit the code block
     const transform = state.transform();
-    transform.insertBlock({ type: opts.exitBlockType });
+    const result = opts.onExit(transform, opts);
 
-    const inserted = transform.state.startBlock;
-    return transform.unwrapNodeByKey(inserted.key).apply();
+    if (result) {
+        return result.apply();
+    }
 }
 
 module.exports = onModEnter;

--- a/lib/options.js
+++ b/lib/options.js
@@ -12,7 +12,15 @@ const DEFAULTS = {
     // Should the plugin handle the select all inside a code container
     selectAll: true,
     // Allow marks inside code blocks
-    allowMarks: false
+    allowMarks: false,
+    // Custom exit handler
+    onExit: (transform, options) => {
+        // Exit the code block
+        transform.insertBlock({ type: options.exitBlockType });
+
+        const inserted = transform.state.startBlock;
+        return transform.unwrapNodeByKey(inserted.key);
+    }
 };
 
 /**
@@ -21,4 +29,3 @@ const DEFAULTS = {
 class Options extends new Record(DEFAULTS) {}
 
 module.exports = Options;
-

--- a/lib/options.js
+++ b/lib/options.js
@@ -14,6 +14,7 @@ const DEFAULTS = {
     // Allow marks inside code blocks
     allowMarks: false,
     // Custom exit handler
+    // exitBlockType option is useless if onExit is provided
     onExit: (transform, options) => {
         // Exit the code block
         transform.insertBlock({ type: options.exitBlockType });


### PR DESCRIPTION
This PR adds an option “onExit” to customize the exit transform.

It defaults to the current behaviour (split as paragraph).