### PR TITLE
Support event.ctrlKey or event.metaKey

### DIFF
--- a/lib/handlers/onKeyDown.js
+++ b/lib/handlers/onKeyDown.js
@@ -36,7 +36,7 @@ function onKeyDown(
     const args = [opts, event, change, editor];
 
     // Select all the code in the block (Mod+a)
-    if (event.key === 'a' && event.metaKey && opts.selectAll) {
+    if (event.key === 'a' && opts.selectAll && (event.ctrlKey || event.metaKey)) {
         return onSelectAll(...args);
     } else if (event.key === KEY_TAB && event.shiftKey) {
         // User is pressing Shift+Tab
@@ -44,7 +44,7 @@ function onKeyDown(
     } else if (event.key == KEY_TAB) {
         // User is pressing Tab
         return onTab(...args);
-    } else if (event.key == KEY_ENTER && event.metaKey && opts.exitBlockType) {
+    } else if (event.key == KEY_ENTER && opts.exitBlockType && (event.ctrlKey || event.metaKey)) {
         // User is pressing Mod+Enter
         return onModEnter(...args);
     } else if (event.key == KEY_ENTER) {


### PR DESCRIPTION
Passes tests and was tested on Windows. Tested with Windows key to emulate Mac OS, but cannot test on Mac directly.