### PR TITLE
Slate 32 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ This plugin uses the following structure for code blocks:
 
 ``` yaml
 nodes:
-  - kind: block
+  - object: block
     type: code_block
     nodes:
-      - kind: block
+      - object: block
         type: code_line
         nodes:
           - text: "A code block is made of..."
-      - kind: block
+      - object: block
         type: code_line
         nodes:
           - text: "...several code lines"

--- a/lib/validation/validateNode.js
+++ b/lib/validation/validateNode.js
@@ -62,7 +62,7 @@ function noOrphanLine(opts: Options) {
         // Match all blocks that are not code blocks
         match(node) {
             return (
-                (node.kind === 'block' || node.kind === 'document') &&
+                (node.object === 'block' || node.object === 'document') &&
                 node.type !== opts.containerType
             );
         },
@@ -107,7 +107,7 @@ function onlyLine(opts: Options) {
             const toRemove = List();
 
             nodes.forEach(child => {
-                if (child.kind === 'text') {
+                if (child.object === 'text') {
                     const lines = deserializeCode(opts, child.text).nodes;
                     toAdd = toAdd.concat(lines);
                     toRemove.push(child);
@@ -149,7 +149,7 @@ function onlyText(opts: Options) {
         validate(node) {
             const { nodes } = node;
 
-            const toRemove = nodes.filterNot(n => n.kind === 'text');
+            const toRemove = nodes.filterNot(n => n.object === 'text');
             if (!toRemove.isEmpty()) {
                 // Remove them, and the rest
                 // will be done in the next validation call.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "slate": "^0.29.0",
-    "slate-react": "^0.10.0"
+    "slate": "^0.32.0",
+    "slate-react": "^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -38,9 +38,9 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.31.0",
+    "slate": "^0.32.0",
     "slate-hyperscript": "^0.4.6",
-    "slate-react": "^0.10.0"
+    "slate-react": "^0.11.4"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/tests/backspace-empty-code/expected.yaml
+++ b/tests/backspace-empty-code/expected.yaml
@@ -1,9 +1,9 @@
 
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: ""

--- a/tests/backspace-empty-code/input.yaml
+++ b/tests/backspace-empty-code/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: ""

--- a/tests/backspace-start/expected.yaml
+++ b/tests/backspace-start/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"

--- a/tests/backspace-start/input.yaml
+++ b/tests/backspace-start/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "    Line 1"

--- a/tests/enter-end-offset/expected.yaml
+++ b/tests/enter-end-offset/expected.yaml
@@ -1,17 +1,17 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some code"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: ""

--- a/tests/enter-end-offset/input.yaml
+++ b/tests/enter-end-offset/input.yaml
@@ -1,13 +1,13 @@
 
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'cursor'
               leaves:
                 - text: "Some code"

--- a/tests/enter-mid-offset/expected.yaml
+++ b/tests/enter-mid-offset/expected.yaml
@@ -1,17 +1,17 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: " code"

--- a/tests/enter-mid-offset/input.yaml
+++ b/tests/enter-mid-offset/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Some code"

--- a/tests/enter-start-offset/expected.yaml
+++ b/tests/enter-start-offset/expected.yaml
@@ -1,17 +1,17 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: ""
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some code"

--- a/tests/enter-start-offset/input.yaml
+++ b/tests/enter-start-offset/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Some code"

--- a/tests/enter-with-indent/expected.yaml
+++ b/tests/enter-with-indent/expected.yaml
@@ -1,23 +1,23 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Li"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    ne 2"

--- a/tests/enter-with-indent/input.yaml
+++ b/tests/enter-with-indent/input.yaml
@@ -1,18 +1,18 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "    Line 2"

--- a/tests/isincodeblock-true/expected.yaml
+++ b/tests/isincodeblock-true/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Hello world"

--- a/tests/isincodeblock-true/input.yaml
+++ b/tests/isincodeblock-true/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Hello world"

--- a/tests/on-exit-block/expected.yaml
+++ b/tests/on-exit-block/expected.yaml
@@ -1,32 +1,32 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Li"
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: ""
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "ne 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 2"

--- a/tests/on-exit-block/input.yaml
+++ b/tests/on-exit-block/input.yaml
@@ -1,19 +1,19 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 2"
 selection:

--- a/tests/paste-middle/expected.yaml
+++ b/tests/paste-middle/expected.yaml
@@ -1,23 +1,23 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "SomeYes"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "No"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Question? code"

--- a/tests/paste-middle/input.yaml
+++ b/tests/paste-middle/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Some code"

--- a/tests/schema-multiline-text/expected.yaml
+++ b/tests/schema-multiline-text/expected.yaml
@@ -1,29 +1,29 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "multiple"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "lines"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "of"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "code"

--- a/tests/schema-multiline-text/input.yaml
+++ b/tests/schema-multiline-text/input.yaml
@@ -1,8 +1,8 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "multiple\nlines\nof\ncode"

--- a/tests/schema-no-marks/expected.yaml
+++ b/tests/schema-no-marks/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some formatted text"

--- a/tests/schema-no-marks/input.yaml
+++ b/tests/schema-no-marks/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: 'Some '
                 - text: 'formatted'

--- a/tests/schema-no-orphan-line/expected.yaml
+++ b/tests/schema-no-orphan-line/expected.yaml
@@ -1,20 +1,20 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some orphan code"
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some other code"

--- a/tests/schema-no-orphan-line/input.yaml
+++ b/tests/schema-no-orphan-line/input.yaml
@@ -1,17 +1,17 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_line
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Some orphan code"
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some other code"

--- a/tests/schema-only-text-2/expected.yaml
+++ b/tests/schema-only-text-2/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "One textTwo text"

--- a/tests/schema-only-text-2/input.yaml
+++ b/tests/schema-only-text-2/input.yaml
@@ -1,20 +1,20 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "One text"
-            - kind: block
+            - object: block
               type: something
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Unwanted block"
-            - kind: text
+            - object: text
               leaves:
                 - text: "Two text"

--- a/tests/schema-only-text/expected.yaml
+++ b/tests/schema-only-text/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: ""

--- a/tests/schema-only-text/input.yaml
+++ b/tests/schema-only-text/input.yaml
@@ -1,15 +1,15 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
             # Contains another block instead of just text nodes
-            - kind: block
+            - object: block
               type: default
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Some\n code"

--- a/tests/schema-single-text/expected.yaml
+++ b/tests/schema-single-text/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "One textTwo textThree text"

--- a/tests/schema-single-text/input.yaml
+++ b/tests/schema-single-text/input.yaml
@@ -1,17 +1,17 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "One text"
-            - kind: text
+            - object: text
               leaves:
                 - text: "Two text"
-            - kind: text
+            - object: text
               leaves:
                 - text: "Three text"

--- a/tests/select-all/expected.yaml
+++ b/tests/select-all/expected.yaml
@@ -1,24 +1,24 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 3"
 selection:

--- a/tests/select-all/input.yaml
+++ b/tests/select-all/input.yaml
@@ -1,26 +1,26 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'a'
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'b'
               leaves:
                 - text: "Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'c'
               leaves:
                 - text: "Line 3"

--- a/tests/shift-tab-middle-offset/expected.yaml
+++ b/tests/shift-tab-middle-offset/expected.yaml
@@ -1,23 +1,23 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "  Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "  Line 3"

--- a/tests/shift-tab-middle-offset/input.yaml
+++ b/tests/shift-tab-middle-offset/input.yaml
@@ -1,25 +1,25 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "  Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "  Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "  Line 3"
 selection:

--- a/tests/shift-tab-multilines/expected.yaml
+++ b/tests/shift-tab-multilines/expected.yaml
@@ -1,23 +1,23 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 3"

--- a/tests/shift-tab-multilines/input.yaml
+++ b/tests/shift-tab-multilines/input.yaml
@@ -1,26 +1,26 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "    Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'end'
               leaves:
                 - text: "    Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 3"
 selection:

--- a/tests/tab-middle-offset/expected.yaml
+++ b/tests/tab-middle-offset/expected.yaml
@@ -1,23 +1,23 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "  Line 3"

--- a/tests/tab-middle-offset/input.yaml
+++ b/tests/tab-middle-offset/input.yaml
@@ -1,25 +1,25 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "  Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "  Line 3"
 selection:

--- a/tests/tab-multilines/expected.yaml
+++ b/tests/tab-multilines/expected.yaml
@@ -1,23 +1,23 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 3"

--- a/tests/tab-multilines/input.yaml
+++ b/tests/tab-multilines/input.yaml
@@ -1,26 +1,26 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Line 1"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'end'
               leaves:
                 - text: "Line 2"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Line 3"
 selection:

--- a/tests/tab-start-offset/expected.yaml
+++ b/tests/tab-start-offset/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "    Some code"

--- a/tests/tab-start-offset/input.yaml
+++ b/tests/tab-start-offset/input.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Some code"

--- a/tests/togglecodeblock-code/expected.yaml
+++ b/tests/togglecodeblock-code/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Hello world"

--- a/tests/togglecodeblock-code/input.yaml
+++ b/tests/togglecodeblock-code/input.yaml
@@ -1,9 +1,9 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           key: 'start'
           leaves:
             - text: "Hello world"

--- a/tests/togglecodeblock-normal/expected.yaml
+++ b/tests/togglecodeblock-normal/expected.yaml
@@ -1,8 +1,8 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Hello world"

--- a/tests/togglecodeblock-normal/input.yaml
+++ b/tests/togglecodeblock-normal/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Hello world"

--- a/tests/unwrapcodeblock-multi-lines/expected.yaml
+++ b/tests/unwrapcodeblock-multi-lines/expected.yaml
@@ -1,14 +1,14 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Hello"
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "world"

--- a/tests/unwrapcodeblock-multi-lines/input.yaml
+++ b/tests/unwrapcodeblock-multi-lines/input.yaml
@@ -1,19 +1,19 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Hello"
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "world"

--- a/tests/unwrapcodeblock-normal/expected.yaml
+++ b/tests/unwrapcodeblock-normal/expected.yaml
@@ -1,8 +1,8 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Hello world"

--- a/tests/unwrapcodeblock-normal/input.yaml
+++ b/tests/unwrapcodeblock-normal/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Hello world"

--- a/tests/unwrapcodeblock-selection/expected.yaml
+++ b/tests/unwrapcodeblock-selection/expected.yaml
@@ -1,8 +1,8 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Hello world"

--- a/tests/unwrapcodeblock-selection/input.yaml
+++ b/tests/unwrapcodeblock-selection/input.yaml
@@ -1,12 +1,12 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               key: 'start'
               leaves:
                 - text: "Hello world"

--- a/tests/wrapcodeblock-normal/expected.yaml
+++ b/tests/wrapcodeblock-normal/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Hello world"

--- a/tests/wrapcodeblock-normal/input.yaml
+++ b/tests/wrapcodeblock-normal/input.yaml
@@ -1,9 +1,9 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           key: 'start'
           leaves:
             - text: "Hello world"

--- a/tests/wrapcodeblock-selection/expected.yaml
+++ b/tests/wrapcodeblock-selection/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Hello world"

--- a/tests/wrapcodeblock-selection/input.yaml
+++ b/tests/wrapcodeblock-selection/input.yaml
@@ -1,9 +1,9 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           key: 'start'
           leaves:
             - text: "Hello world"

--- a/tests/wrapcodeblock-with-inline/expected.yaml
+++ b/tests/wrapcodeblock-with-inline/expected.yaml
@@ -1,11 +1,11 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: code_block
       nodes:
-        - kind: block
+        - object: block
           type: code_line
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Hello world"

--- a/tests/wrapcodeblock-with-inline/input.yaml
+++ b/tests/wrapcodeblock-with-inline/input.yaml
@@ -1,16 +1,16 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           key: 'start'
           leaves:
             - text: "Hello "
-        - kind: inline
+        - object: inline
           type: link
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "world"
 selection:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,6 +2907,10 @@ lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
 
+lodash@^4.1.1:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -3791,9 +3795,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-base64-serializer@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.8.tgz#fef19b2cb799f5bc5f6b987834048d662102a45a"
+slate-base64-serializer@^0.2.23:
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.23.tgz#d19b8a29ac800135d8c359f9153ba4af6210c407"
   dependencies:
     isomorphic-base64 "^1.0.2"
 
@@ -3801,9 +3805,9 @@ slate-dev-logger@^0.1.32:
   version "0.1.32"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.32.tgz#76b73d75a149d0eac0cab134965aca14f7542888"
 
-slate-dev-logger@^0.1.36:
-  version "0.1.36"
-  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.36.tgz#ecdb37dbf944dfc742bab23b6a20d5a0472db95e"
+slate-dev-logger@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
 
 slate-hyperscript@^0.4.6:
   version "0.4.6"
@@ -3813,21 +3817,21 @@ slate-hyperscript@^0.4.6:
     is-plain-object "^2.0.4"
     slate-dev-logger "^0.1.32"
 
-slate-plain-serializer@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.4.6.tgz#1fa04ff7c9fd74ed5cedcdfdad8120eb4c4cef6a"
+slate-plain-serializer@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.5.4.tgz#ba5a1713a50e6e9020e080c10e5869f38820dc96"
   dependencies:
-    slate-dev-logger "^0.1.32"
+    slate-dev-logger "^0.1.39"
 
-slate-prop-types@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.4.6.tgz#ff7927430d03fa30bfa44ead5367867b209e5985"
+slate-prop-types@^0.4.21:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.4.21.tgz#618214e867d44469fb7da9b8ac4ea68e9e0fa56b"
   dependencies:
-    slate-dev-logger "^0.1.32"
+    slate-dev-logger "^0.1.39"
 
-slate-react@^0.10.0:
-  version "0.10.11"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.10.11.tgz#5fbfbf0da2dd726df468d788d2bd81dd578a15a3"
+slate-react@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.11.4.tgz#c24d2cb8a3724e9a41c1f3566136ab8d3fa1ac8e"
   dependencies:
     debug "^2.3.2"
     get-window "^1.1.1"
@@ -3835,18 +3839,23 @@ slate-react@^0.10.0:
     is-in-browser "^1.1.3"
     is-window "^1.0.2"
     keycode "^2.1.2"
+    lodash "^4.1.1"
     prop-types "^15.5.8"
     react-immutable-proptypes "^2.1.0"
     react-portal "^3.1.0"
     selection-is-backward "^1.0.0"
-    slate-base64-serializer "^0.2.8"
-    slate-dev-logger "^0.1.32"
-    slate-plain-serializer "^0.4.6"
-    slate-prop-types "^0.4.6"
+    slate-base64-serializer "^0.2.23"
+    slate-dev-logger "^0.1.39"
+    slate-plain-serializer "^0.5.4"
+    slate-prop-types "^0.4.21"
 
-slate@^0.31.0:
-  version "0.31.7"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.31.7.tgz#595b5e4ef45f7385a4535a4595fb0c6ebe326b45"
+slate-schema-violations@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.2.tgz#45f2e6ed2e77c98925bb1e159bf24cad9dc7f8ac"
+
+slate@^0.32.0:
+  version "0.32.4"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.32.4.tgz#dcc971d1cf4e4b7ac158b5bac9c39c9915805435"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"
@@ -3854,7 +3863,8 @@ slate@^0.31.0:
     is-empty "^1.0.0"
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
-    slate-dev-logger "^0.1.36"
+    slate-dev-logger "^0.1.39"
+    slate-schema-violations "^0.1.2"
     type-of "^2.0.1"
 
 slice-ansi@1.0.0:


### PR DESCRIPTION
`.kind` becomes `.object`. Prevents deprecation warnings being thrown in 32 onwards.