### PR TITLE
Improve inline and block normalization inside code lines

### DIFF
--- a/lib/validation/schema.js
+++ b/lib/validation/schema.js
@@ -5,7 +5,8 @@ import {
     CHILD_TYPE_INVALID,
     CHILD_INVALID,
     PARENT_TYPE_INVALID,
-    PARENT_INVALID
+    PARENT_INVALID,
+    CHILD_OBJECT_INVALID
 } from '@gitbook/slate-schema-violations';
 import { List } from 'immutable';
 
@@ -42,6 +43,9 @@ function schema(opts: Options): Object {
                         case PARENT_INVALID:
                         case PARENT_TYPE_INVALID:
                             return noOrphanLine(opts, change, context);
+                        case CHILD_INVALID:
+                        case CHILD_OBJECT_INVALID:
+                            return onlyTextInCode(opts, change, context);
                         default:
                             return undefined;
                     }
@@ -111,6 +115,27 @@ function onlyLine(opts: Options, change: Change, context: Object) {
     });
 
     return change;
+}
+
+/**
+ * A rule that ensure code lines only contain text
+ */
+function onlyTextInCode(
+    opts: Options,
+    change: Change,
+    context: Object
+): ?Change {
+    const { node } = context;
+
+    if (node.object === 'inline' || node.object === 'block') {
+        node.nodes.forEach(child => {
+            change.unwrapNodeByKey(child.key, { normalize: false });
+        });
+
+        return change;
+    }
+
+    return undefined;
 }
 
 /**

--- a/tests/schema-no-inlines/change.js
+++ b/tests/schema-no-inlines/change.js
@@ -1,0 +1,6 @@
+import Slate from '@gitbook/slate';
+
+export default function(plugin, change) {
+    const schema = new Slate.Schema(plugin.schema);
+    return change.normalize(schema);
+}

--- a/tests/schema-no-inlines/expected.js
+++ b/tests/schema-no-inlines/expected.js
@@ -5,9 +5,7 @@ export default (
     <value>
         <document>
             <code_block>
-                <code_line>Some</code_line>
-                <code_line>{' code'}</code_line>
-                <code_line />
+                <code_line>Some link in code</code_line>
             </code_block>
         </document>
     </value>

--- a/tests/schema-no-inlines/input.js
+++ b/tests/schema-no-inlines/input.js
@@ -5,10 +5,12 @@ export default (
     <value>
         <document>
             <code_block>
-                <code_line>Some</code_line>
-                <code_line>{' code'}</code_line>
-                <code_line />
+                <code_line>
+                    Some <inline type="link">link</inline> in code
+                </code_line>
             </code_block>
         </document>
     </value>
 );
+
+// BITE


### PR DESCRIPTION
It causes issues when you have inlines or blocks inside a code, they are simply deleted. Now their text is preserved. Fixes https://github.com/GitbookIO/gitbook-new/issues/2887

Details:

As stated in https://github.com/GitbookIO/gitbook-new/issues/2887 it is not possible to paste an inline link inside code blocks. This plugin should handle the onPaste already, but in gitbook, we had a onPaste for links that was overriding this behavior. So just reordering plugins works (will do). But I think this is an added safety.